### PR TITLE
[SPOT-92] : DE 장소 확정하면 공유하기 버튼으로 변경

### DIFF
--- a/src/features/detail/ui/PlaceButton.tsx
+++ b/src/features/detail/ui/PlaceButton.tsx
@@ -9,8 +9,9 @@ interface PlaceButtonProps {
   name: string;
   isChanged: boolean;
   isConfirmed: boolean;
+  onComplete?: () => void;
 }
-export const PlaceButton = ({ eventId, placeId, name, isChanged, isConfirmed }: PlaceButtonProps) => {
+export const PlaceButton = ({ eventId, placeId, name, isChanged, isConfirmed, onComplete }: PlaceButtonProps) => {
   const { mutate, isPending } = useSetPlace();
   const [isChangedOpen, setIsChangedOpen] = useState(false);
   const [isConfirmedOpen, setIsConfirmedOpen] = useState(false);
@@ -30,6 +31,7 @@ export const PlaceButton = ({ eventId, placeId, name, isChanged, isConfirmed }: 
         onSuccess: () => {
           setIsConfirmedOpen(false);
           setIsChangedOpen(false);
+          onComplete?.();
         },
       }
     );

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -106,6 +106,7 @@ const DetailPage = () => {
         name={data.name}
         isChanged={data.isChanged}
         isConfirmed={data.isConfirmed}
+        onComplete={() => setIsOpenShareModal(true)}
       />
       {isOpenShareModal && (
         <ShareModal


### PR DESCRIPTION
# 🛠 구현 사항

- [x] DE 장소 확정하면 공유하기 버튼으로 변경

# ❓ 질문

- X

# 📸 화면 캡처

# 💬 리뷰 요구사항
- 지금 로직 상 DE 버튼에서 약속 장소 확정, 바꾸는 버튼이 동일한 컴포넌트로 이루어져 있어서 약속 장소 확정 시, 변경 시 공유하기 모달이 뜹니다. 추후 로직 변경 시 버튼을 분리할 예정입니다! 